### PR TITLE
#000002 Resizing textarea of note doesn't work

### DIFF
--- a/static/star_timer/js/main.js
+++ b/static/star_timer/js/main.js
@@ -270,9 +270,10 @@ let Main = {
 
     // メモ反映
     setNote: function(note){
-      $('#timer-record-note').focus();
-      $('#timer-record-note').val(note);
-      $('#timer-record-note').blur();
+        $('#timer-record-note').focus();
+        $('#timer-record-note').val(note);
+        $('#timer-record-note').blur();
+        M.textareaAutoResize($('#timer-record-note'));
     },
 
     // メモのみ保存API


### PR DESCRIPTION
画面更新時にtextareaのリサイズが行われなかったのでmaterialize標準メソッド M.textareaAutoResize($('#*********'));を追加